### PR TITLE
[API-11050] fix: sanitize locale-suffixed keys for XML element names

### DIFF
--- a/vendor/Luracast/Restler/Format/XmlFormat.php
+++ b/vendor/Luracast/Restler/Format/XmlFormat.php
@@ -335,6 +335,17 @@ class XmlFormat extends Format
         return $r;
     }
 
+    /**
+     * Sanitize a key so it is a valid XML element name.
+     *
+     * Some API responses include locale-suffixed keys (e.g. "fullName@fr")
+     * produced by Unicity's localization layer. The '@' character is not
+     * allowed in XML names and causes XMLWriter::startElement() to throw a
+     * fatal error. Replacing '@' with '_' keeps the output well-formed
+     * while preserving readability.
+     *
+     * @see https://app.clickup.com/t/86cwqr1f2  API-11050
+     */
     private static function sanitizeElementName(string $name): string
     {
         return str_replace('@', '_', $name);

--- a/vendor/Luracast/Restler/Format/XmlFormat.php
+++ b/vendor/Luracast/Restler/Format/XmlFormat.php
@@ -147,6 +147,7 @@ class XmlFormat extends Format
                     }
                     $key = static::$defaultTagName;
                 }
+                $xmlKey = static::sanitizeElementName((string)$key);
                 $useNS = static::$useNamespaces
                     && !empty(static::$namespacedProperties[$key])
                     && false === strpos($key, ':');
@@ -157,22 +158,22 @@ class XmlFormat extends Format
                             $useNS
                                 ? $xml->startElementNs(
                                 static::$namespacedProperties[$key],
-                                $key,
+                                $xmlKey,
                                 null
                             )
-                                : $xml->startElement($key);
-                            $this->write($xml, $v, $key);
+                                : $xml->startElement($xmlKey);
+                            $this->write($xml, $v, $xmlKey);
                             $xml->endElement();
                         }
                     } else {
                         $useNS
                             ? $xml->startElementNs(
                             static::$namespacedProperties[$key],
-                            $key,
+                            $xmlKey,
                             null
                         )
-                            : $xml->startElement($key);
-                        $this->write($xml, $value, $key);
+                            : $xml->startElement($xmlKey);
+                        $this->write($xml, $value, $xmlKey);
                         $xml->endElement();
                     }
                     continue;
@@ -180,17 +181,17 @@ class XmlFormat extends Format
                     $value = $value ? 'true' : 'false';
                 }
                 if (isset($attributes[$key])) {
-                    $xml->writeAttribute($useNS ? static::$namespacedProperties[$key] . ':' . $key : $key, $value);
+                    $xml->writeAttribute($useNS ? static::$namespacedProperties[$key] . ':' . $xmlKey : $xmlKey, $value);
                 } else {
                     $useNS
                         ?
                         $xml->startElementNs(
                             static::$namespacedProperties[$key],
-                            $key,
+                            $xmlKey,
                             null
                         )
-                        : $xml->startElement($key);
-                    $this->write($xml, $value, $key);
+                        : $xml->startElement($xmlKey);
+                    $this->write($xml, $value, $xmlKey);
                     $xml->endElement();
                 }
             }
@@ -332,6 +333,11 @@ class XmlFormat extends Format
             );
         }
         return $r;
+    }
+
+    private static function sanitizeElementName(string $name): string
+    {
+        return str_replace('@', '_', $name);
     }
 
     public static function setType($value)


### PR DESCRIPTION
## 🚀 Changes

- Introduce `sanitizeElementName()` to replace `@` with `_` in XML element names
- Apply sanitization across all `startElement()` / `startElementNs()` / `writeAttribute()` call sites in `XmlFormat::write()`

## 🔗 ClickUp Ticket(s)

- API-11050

## 📸 Test Plan

- Hydra-app unit test suite: 0 new failures (19 errors and 8 failures are pre-existing on `release`, unrelated to this change)
- Datadog log search (30 days): confirmed no clients request `Accept: application/xml` from hydra-app — the XML output with locale-suffixed fields was always crashing with a fatal error, so no consumer relied on any particular element name format

## 🤔 Anything Else (optional)

`@` is not valid in XML element names per the XML spec — there is no escape mechanism for element names (unlike text content). The fix operates at the serialization layer only; the PHP object representation (`fullName@fr`) is unchanged and all internal consumers (mappingservice-app, gorgon-app-v2, etc.) use PHP object properties, not XML output.