### PR TITLE
Fix null parameter in CommentParser::formatReturn

### DIFF
--- a/vendor/Luracast/Restler/CommentParser.php
+++ b/vendor/Luracast/Restler/CommentParser.php
@@ -409,7 +409,7 @@ class CommentParser
 
     private function formatReturn(array $value)
     {
-        $data = explode('|', array_shift($value));
+        $data = explode('|', (string) array_shift($value));
         $r = array(
             'type' => count($data) == 1 ? $data[0] : $data
         );


### PR DESCRIPTION
## Summary
- Cast `array_shift($value)` to string before `explode('|', ...)` in `CommentParser::formatReturn`
- Prevents a PHP 8.1 deprecation notice when a `@return` docblock has no type
- Matches the same fix style as f580060 (Resources.php null-strpos guard)

## Context
Reproduced in `hydra-app` prod logs:

```
explode(): Passing null to parameter #2 ($string) of type string is deprecated
at /var/www/app/src/submodules/Unicity/Restler/vendor/Luracast/Restler/CommentParser.php:412
```

`array_shift($value)` returns null when the `@return` annotation has no type (bare `@return` lines or annotations Restler couldn't tokenize). The cast coerces that to `''` so `explode()` returns `['']` — same behaviour as before PHP 8.1, just without the deprecation.

## Test plan
- [ ] Hydra prod logs stop emitting the `CommentParser.php:412` deprecation after the submodule bump in Octopus
- [ ] No change in Restler unit-test output (the fix is null-safety only; non-null inputs go through `(string)` unchanged)

<img width="603" height="414" alt="arp7y3" src="https://github.com/user-attachments/assets/354048ca-9998-4260-95e3-ef9b3e500546" />
