### PR TITLE
Bump PHP floor to 8.1 and drop unused twig/illuminate dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "bshaffer/oauth2-server-php":"Restler can provide OAuth2 authentication using this library (see require-dev for details)"
     },
     "require":{
-        "php":">=5.3.0"
+        "php":">=8.1"
     },
     "require-dev":{
         "luracast/explorer":"*",
@@ -43,8 +43,6 @@
         "zendframework/zendamf":"dev-master",
         "symfony/yaml":"*",
         "mustache/mustache": "dev-master",
-        "twig/twig": "v1.13.0",
-        "illuminate/view": "4.2.*",
         "bshaffer/oauth2-server-php":"v1.0"
     },
     "repositories":[


### PR DESCRIPTION
## Summary

Removes the `twig/twig` (v1.13.0) and `illuminate/view` (4.2.*) entries from `require-dev`. Both were optional adapters for the `HtmlFormat` template engine that no consumer in this org uses, and both upstream branches are EOL.

This resolves all 7 open Dependabot alerts:

- #1 — CVE-2019-9942 — twig sandbox info disclosure
- #2 — CVE-2022-39261 — twig path traversal
- #3 — CVE-2021-43808 — laravel blade XSS
- #4 — CVE-2015-7809 — twig RCE
- #5 — CVE-2024-45411 — twig sandbox bypass
- #6 — CVE-2024-51754 — twig __toString
- #7 — CVE-2024-51755 — twig __isset / array-access

Both packages remain documented in the `suggest` block, so anyone who wants to opt back into the HtmlFormat Twig/Blade adapters can `composer require` them at the version they need.

Also bumps `require.php` from `>=5.3.0` to `>=8.1` to match what consumers (`hydra-app`) actually run.

## Verification

- `vendor/illuminate` and `vendor/twig` are already `.gitignore`-d — no vendored files to remove.
- `git grep -E 'new HtmlFormat|Twig_'` against `Octopus/components/services/hydra-app` returns no hits.
- hydra-app's own `composer.json` does not depend on `twig/twig` or `illuminate/view` (it uses Mustache for templating).

## Test Plan

- [ ] `composer validate` passes locally
- [ ] All 7 Dependabot alerts auto-close on merge
- [ ] Follow-up: bump the Restler submodule pointer in `Unicity/Octopus`